### PR TITLE
Fix list files not being included in the extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   },
   "scripts": {
     "vscode:prepublish": "pnpm run compile",
-    "compile": "tsc -p ./",
+    "copy-files": "cp src/*.list out/ && cp -r src/toptal out/toptal",
+    "compile": "tsc -p ./ && pnpm run copy-files",
     "watch": "tsc -watch -p ./",
     "pretest": "pnpm run compile && pnpm run lint",
     "lint": "eslint src",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,9 @@
+import * as path from "path";
+
 export const EXTENSION_PATHS = {
-  IGNORE_TYPES: "src/ignore-types.list",
-  TEMPLATES_LIST: "src/templates.list",
-  TEMPLATES_FOLDER: "src/toptal/templates",
+  IGNORE_TYPES: path.join(path.basename(__dirname), "ignore-types.list"),
+  TEMPLATES_LIST: path.join(path.basename(__dirname), "templates.list"),
+  TEMPLATES_FOLDER: path.join(__dirname, "toptal", "templates"),
 } as const;
 
 export const MESSAGES = {


### PR DESCRIPTION
Trying to use this extension currently results in the following error:

```
Error: Failed to read ignore types: Error: ENOENT: no such file or directory, open '<path to vscode extension install location>/src/ignore-types.list'
```

This PR adds a step to compilation to copy the list files into the output dir, and fixes the constants to correctly resolve the relative location of them.